### PR TITLE
Add support for HTTP Basic Auth to Sensu API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .yardoc
+.idea
 Gemfile.lock
 InstalledFiles
 _yardoc


### PR DESCRIPTION
I saw that you had config vars setup already for basic auth to Sensu API, so I just used them and wrote the code to add the proper headers when present.
